### PR TITLE
fix: Veganify name change

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Twitter](https://twitter.com): Microblogging app.
 * [Uber Web](https://m.uber.com): Ridesharing app.
 * [Unalengua IPA Translator](https://unalengua.com/ipa): Translate to IPA.
-* [VeganCheck](https://vegancheck.me): Check if a product is vegan or not.
+* [Veganify](https://veganify.app): Check if a product is vegan or not.
 * [VeggieTables](https://veggietables.org): Track your crops and farming activities.
 * [Versus](https://versus.com/en): Consumer electronics shopping.
 * [Wave-PD1](https://alexgibson.github.io/wavepad/): Synth toy.


### PR DESCRIPTION
VeganCheck had to change its name due to legal reasons. This should also be reflected in all linking pages/repos.